### PR TITLE
Update Chrome extension for compatibility with version 134.0.6998.46

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,10 @@ The Quick link Chrome Extension allows users to define and open predefined links
 4. Click on "Load unpacked" and select the extension's folder.
 5. The Quick link Chrome Extension should now be installed and active.
 
+## Compatibility
+
+The extension is compatible with Chrome version 134.0.6998.46.
+
 ## Usage
 
 1. Click on the extension icon in the Chrome toolbar to open the popup window.

--- a/background.js
+++ b/background.js
@@ -1,0 +1,3 @@
+chrome.runtime.onInstalled.addListener(() => {
+  console.log('Service worker installed');
+});

--- a/manifest.json
+++ b/manifest.json
@@ -1,15 +1,19 @@
 {
-  "manifest_version": 2,
+  "manifest_version": 3,
   "name": "Quick link",
   "version": "0.0.1",
   "permissions": ["tabs", "storage"],
+  "host_permissions": ["http://*/*", "https://*/*"],
   "options_page": "options.html",
-  "browser_action": {
+  "action": {
     "default_popup": "popup.html",
     "default_icon": {
       "16": "images/icon16.png",
       "64": "images/icon64.png",
       "128": "images/icon128.png"
     }
+  },
+  "background": {
+    "service_worker": "background.js"
   }
 }

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Quick link",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "permissions": ["tabs", "storage"],
   "host_permissions": ["http://*/*", "https://*/*"],
   "options_page": "options.html",

--- a/options.js
+++ b/options.js
@@ -1,14 +1,15 @@
-// Load existing links from storage
-chrome.storage.sync.get('links', function(data) {
+async function loadLinks() {
+    let data = await chrome.storage.sync.get('links');
     if (data.links) {
         data.links.forEach(addLinkField);
     } else {
-        var defaultLink = {name: "Link 1", url: "http://example.com"};
-        chrome.storage.sync.set({links: [defaultLink]}, function() {
-            addLinkField(defaultLink);
-        });
+        let defaultLink = {name: "Link 1", url: "http://example.com"};
+        await chrome.storage.sync.set({links: [defaultLink]});
+        addLinkField(defaultLink);
     }
-});
+}
+
+loadLinks();
 
 // Add new link input field with a remove button
 document.getElementById('addLink').onclick = function() {
@@ -58,7 +59,7 @@ function addLinkField(link) {
     document.getElementById('linksContainer').appendChild(div);
 }
 
-function saveLinks() {
+async function saveLinks() {
     var divs = document.getElementById('linksContainer').getElementsByTagName('div');
     var links = [];
     for (var i = 0; i < divs.length; i++) {
@@ -66,5 +67,5 @@ function saveLinks() {
         var link = {name: inputs[0].value, url: inputs[1].value};
         links.push(link);
     }
-    chrome.storage.sync.set({links: links});
+    await chrome.storage.sync.set({links: links});
 }

--- a/popup.js
+++ b/popup.js
@@ -1,5 +1,5 @@
-// Load existing links from storage and create input fields
-chrome.storage.sync.get('links', function(data) {
+async function loadLinks() {
+    let data = await chrome.storage.sync.get('links');
     if (data.links) {
         data.links.forEach(function(link, index) {
             var div = document.createElement('div');
@@ -50,7 +50,9 @@ chrome.storage.sync.get('links', function(data) {
             }
         }
     }
-});
+}
+
+loadLinks();
 
 document.getElementById('options').onclick = function() {
     if (chrome.runtime.openOptionsPage) {


### PR DESCRIPTION
Update the extension to be compatible with Chrome version 134.0.6998.46.

* **manifest.json**
  - Update `manifest_version` to 3.
  - Change `browser_action` to `action`.
  - Add `background` property with `service_worker`.
  - Add `host_permissions` for `http://*/*` and `https://*/*`.

* **options.js**
  - Update `chrome.storage.sync.get` and `chrome.storage.sync.set` to use Promises.
  - Refactor code to use async/await for loading and saving links.

* **popup.js**
  - Update `chrome.storage.sync.get` to use Promises.
  - Refactor code to use async/await for loading links.

* **README.md**
  - Add a separate block "Compatibility" mentioning compatibility with Chrome version 134.0.6998.46.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/sergey-chegaev/quick-link/pull/1?shareId=c14a7a7a-d2fc-4606-ba07-5254c2840063).